### PR TITLE
OCP 3.10 Compatibility Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ EOF
 ```
 _Note: `otherName` value should match the configuration you are using in the pivproxy.conf. The default uses the msUPN name type._
 
-Once the client certificate configuration has been saved and adjusted as needed the rest of the PKI material can be generated. Follow the prompts as appropriate on each command if needed.
+Once the client certificate configuration has been saved and adjusted as needed the rest of the PKI material can be generated. Follow the prompts as appropriate on each command if needed _Warning: Failure to add/set a CN will render the certificate unusable._
 ```bash
 []$ openssl genrsa -out client_cert.key 2048
 []$ openssl req -new -key client_cert.key -sha512 -out client_cert.csr

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ identityProviders:
       kind: RequestHeaderIdentityProvider
       challengeURL: "https://<public pivproxy url>/challenging-proxy/oauth/authorize?${query}"
       loginURL: "https://<public pivproxy url>/login-proxy/oauth/authorize?${query}"
-      clientCA: /etc/origin/proxy/proxyca.crt
+      clientCA: /etc/origin/master/proxy/proxyca.crt
       clientCommonNames:
        - <public pivproxy url>
        - system:proxy

--- a/pivproxy.conf
+++ b/pivproxy.conf
@@ -119,7 +119,7 @@ SSLSessionCacheTimeout 300
     RequestHeader set X-Remote-User "%{X_LOWER_USER}e" env=X_LOWER_USER
 
     # rewrite the above variable to strip the `@agency.gov` portion
-    RequestHeader edit X-Remote-User "([^@]+)@.*" $1
+    RequestHeader edit X-Remote-User "([^@]+)(@.*)?" $1
 
   </ProxyMatch>
 </VirtualHost>


### PR DESCRIPTION
Added updated information to README.md related to some commands being deprecated. Clarified a few things around certificate use. Moved base location of proxy certificates because of the podified master services.

The pivproxy.conf used by HTTPD has also been updated to support better username handling (usernames that are not email addresses) right out of the box.
